### PR TITLE
Add version subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Commands:
   fmt          Format HTML documents
   lsp          Start the Super LSP
   help         Show this menu and exit
+  version      Print Super's version and exit
 
 General Options:
-  --help, -h   Print command specific usage  
+  --help, -h   Print command specific usage
 ```
 
 ### Diagnostics
@@ -59,7 +60,7 @@ Before:
 
 After:
 ```html
-<div> 
+<div>
     <p>Foo</p>
 </div>
 ```
@@ -87,9 +88,9 @@ Before:
 
 After:
 ```html
-<div 
-   foo="bar" 
-   style="verylongstring" 
+<div
+   foo="bar"
+   style="verylongstring"
 >
     Foo
 </div>
@@ -99,8 +100,8 @@ After:
 
 Before:
 ```html
-<div 
-   foo="bar" 
+<div
+   foo="bar"
    style="verylongstring">
     Foo
 </div>
@@ -117,7 +118,7 @@ After:
 #### VSCode
 1. Download a prebuilt version of `superhtml` from the Releases section (or build it yourself).
 2. Put `superhtml` in your `PATH`.
-3. Install the [Super HTML VSCode extension](https://marketplace.visualstudio.com/items?itemName=LorisCro.super). 
+3. Install the [Super HTML VSCode extension](https://marketplace.visualstudio.com/items?itemName=LorisCro.super).
 
 #### Helix
 Add to your `.config/helix/languages.toml`:
@@ -147,7 +148,7 @@ Follow your editor specific intructions on how to define a new Language Server f
 SuperHTML is also a HTML templating language. More on that soon.
 
 ## Contributing
-SuperHTML tracks the latest Zig release (0.13.0 at the moment of writing). 
+SuperHTML tracks the latest Zig release (0.13.0 at the moment of writing).
 
 ### Contributing to the HTML paser & LSP
 Contributing to the HTML parser and LSP doesn't require you to be familiar with the templating language, basically limiting the scope of what you have to worry about to:
@@ -163,4 +164,3 @@ You can run `zig test src/html/Ast.zig` to run parser unit tests without needing
 Running `zig build` will compile the Super CLI tool, allowing you to also then test the LSP behavior directly from your favorite editor.
 
 The LSP will log in your cache directory so you can `tail -f ~/.cache/super/super.log` to see what happens with the LSP.
-

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -22,6 +22,7 @@ pub const std_options: std.Options = .{
 };
 
 var lsp_mode = false;
+
 pub fn panic(
     msg: []const u8,
     trace: ?*std.builtin.StackTrace,
@@ -52,7 +53,7 @@ pub fn panic(
     std.process.exit(1);
 }
 
-pub const Command = enum { fmt, lsp, help };
+pub const Command = enum { fmt, lsp, help, version };
 
 pub fn main() !void {
     var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .{};
@@ -76,6 +77,7 @@ pub fn main() !void {
         .fmt => fmt_exe.run(gpa, args[2..]),
         .lsp => lsp_exe.run(gpa, args[2..]),
         .help => fatalHelp(),
+        .version => printVersion(),
     } catch |err| fatal("unexpected error: {s}\n", .{@errorName(err)});
 }
 
@@ -88,15 +90,21 @@ fn oom() noreturn {
     fatal("oom\n", .{});
 }
 
+fn printVersion() noreturn {
+    std.debug.print("{s}\n", .{version});
+    std.process.exit(0);
+}
+
 fn fatalHelp() noreturn {
     fatal(
         \\Usage: super COMMAND [OPTIONS]
         \\
-        \\Commands: 
+        \\Commands:
         // \\  check        Check HTML documents for syntax errors
         \\  fmt          Format HTML documents
         \\  lsp          Start the Super LSP
         \\  help         Show this menu and exit
+        \\  version      Print Super's version and exit
         \\
         \\General Options:
         \\  --help, -h   Print command specific usage


### PR DESCRIPTION
I guess this is mostly self-explanatory (i.e. version string was already present, I've just added another subcommand and a switch case to check for it). Other 'changes' are just a result of zed removing trailing whitespace on save; hope this is not a problem.

Also, why is help message treated as a fatal _error_ (i.e. it returns 1 instead of 0)? It is a valid command after all.
