### PR TITLE
CSS parser

### DIFF
--- a/src/css.zig
+++ b/src/css.zig
@@ -1,0 +1,7 @@
+pub const Tokenizer = @import("css/Tokenizer.zig");
+pub const Stylesheet = @import("css/Stylesheet.zig");
+
+test {
+    _ = Tokenizer;
+    _ = Stylesheet;
+}

--- a/src/css.zig
+++ b/src/css.zig
@@ -1,7 +1,7 @@
 pub const Tokenizer = @import("css/Tokenizer.zig");
-pub const Stylesheet = @import("css/Stylesheet.zig");
+pub const Ast = @import("css/Ast.zig");
 
 test {
     _ = Tokenizer;
-    _ = Stylesheet;
+    _ = Ast;
 }

--- a/src/css/Ast.zig
+++ b/src/css/Ast.zig
@@ -169,7 +169,6 @@ pub fn render(self: Ast, src: []const u8, out_stream: anytype) !void {
         }
 
         try rule.render(src, out_stream, 0);
-        _ = try out_stream.write("\n");
     }
 }
 
@@ -321,7 +320,6 @@ test {
         \\p {
         \\    color: red;
         \\}
-        \\
     ;
 
     const ast = try Ast.init(std.testing.allocator, src);

--- a/src/css/Ast.zig
+++ b/src/css/Ast.zig
@@ -1,0 +1,254 @@
+const std = @import("std");
+const Tokenizer = @import("Tokenizer.zig");
+
+const Ast = @This();
+
+pub const Rule = union(enum) {
+    style: Style,
+    at: At,
+
+    pub const Style = struct {
+        selectors: []const Selector,
+        declarations: []const Declaration,
+
+        pub const Selector = union(enum) {
+            simple: Simple,
+
+            pub const Simple = struct {
+                element_name: ?ElementName,
+
+                pub const ElementName = union(enum) {
+                    name: Tokenizer.Span,
+                    all,
+                };
+            };
+        };
+
+        pub const Declaration = struct {
+            property: Tokenizer.Span,
+            value: Expression,
+
+            pub const Expression = union(enum) {
+                keyword: Tokenizer.Span,
+            };
+        };
+
+        pub fn deinit(self: Style, allocator: std.mem.Allocator) void {
+            allocator.free(self.selectors);
+            allocator.free(self.declarations);
+        }
+    };
+
+    pub const At = struct {};
+
+    pub fn deinit(self: Rule, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .style => |style| style.deinit(allocator),
+            .at => @panic("TODO"),
+        }
+    }
+};
+
+rules: []const Rule,
+
+const State = struct {
+    allocator: std.mem.Allocator,
+    tokenizer: Tokenizer,
+    src: []const u8,
+    reconsumed: ?Tokenizer.Token,
+
+    fn consume(self: *State) ?Tokenizer.Token {
+        if (self.reconsumed) |tok| {
+            self.reconsumed = null;
+            return tok;
+        }
+
+        return self.tokenizer.next(self.src);
+    }
+
+    fn reconsume(self: *State, token: Tokenizer.Token) void {
+        std.debug.assert(self.reconsumed == null);
+
+        self.reconsumed = token;
+    }
+
+    fn peek(self: *State) ?Tokenizer.Token {
+        const token = self.consume();
+        if (token) |tok| self.reconsume(tok);
+
+        return token;
+    }
+};
+
+pub fn init(allocator: std.mem.Allocator, src: []const u8) error{OutOfMemory}!Ast {
+    if (src.len > std.math.maxInt(u32)) @panic("too long");
+
+    var state: State = .{
+        .allocator = allocator,
+        .tokenizer = .{},
+        .src = src,
+        .reconsumed = null,
+    };
+
+    return .{
+        .rules = try parseRules(&state),
+    };
+}
+
+fn parseRules(s: *State) ![]const Rule {
+    var rules = std.ArrayList(Rule).init(s.allocator);
+    defer rules.deinit();
+
+    while (true) {
+        if (s.consume()) |token| {
+            switch (token) {
+                .cdo => @panic("TODO"),
+                .cdc => @panic("TODO"),
+                .at_keyword => @panic("TODO"),
+                else => {
+                    s.reconsume(token);
+
+                    const rule = .{
+                        .style = try parseStyleRule(s),
+                    };
+
+                    try rules.append(rule);
+                },
+            }
+        } else break;
+    }
+
+    return try rules.toOwnedSlice();
+}
+
+fn parseStyleRule(s: *State) !Rule.Style {
+    var selectors = std.ArrayList(Rule.Style.Selector).init(s.allocator);
+    defer selectors.deinit();
+
+    var declarations = std.ArrayList(Rule.Style.Declaration).init(s.allocator);
+    defer declarations.deinit();
+
+    // TODO: Support multiple selectors
+    try selectors.append(try parseSelector(s));
+
+    if (s.consume()) |token| {
+        switch (token) {
+            .open_curly => {},
+            else => @panic("TODO"),
+        }
+    } else {
+        @panic("TODO");
+    }
+
+    // TODO: Support multiple declarations
+    try declarations.append(try parseDeclaration(s));
+
+    if (s.peek()) |token| {
+        if (token == .semicolon) _ = s.consume();
+    }
+
+    if (s.consume()) |token| {
+        switch (token) {
+            .close_curly => {},
+            else => @panic("TODO"),
+        }
+    } else {
+        @panic("TODO");
+    }
+
+    return .{
+        .selectors = try selectors.toOwnedSlice(),
+        .declarations = try declarations.toOwnedSlice(),
+    };
+}
+
+fn parseSelector(s: *State) !Rule.Style.Selector {
+    // TODO: Support other selectors
+
+    return .{
+        .simple = try parseSimpleSelector(s),
+    };
+}
+
+fn parseDeclaration(s: *State) !Rule.Style.Declaration {
+    const property = if (s.consume()) |token| switch (token) {
+        .ident => |ident| ident,
+        else => @panic("TODO"),
+    } else @panic("TODO");
+
+    if (s.consume()) |token| {
+        switch (token) {
+            .colon => {},
+            else => @panic("TODO"),
+        }
+    } else {
+        @panic("TODO");
+    }
+
+    return .{
+        .property = property,
+        .value = try parseDeclarationExpression(s),
+    };
+}
+
+fn parseSimpleSelector(s: *State) !Rule.Style.Selector.Simple {
+    // TODO: Support hash, class, etc.
+    // TODO: Support `*`
+
+    return .{
+        .element_name = .{
+            .name = s.consume().?.ident,
+        },
+    };
+}
+
+fn parseDeclarationExpression(s: *State) !Rule.Style.Declaration.Expression {
+    // TODO: Support operators
+    // TODO: Support other expression types
+
+    return .{ .keyword = s.consume().?.ident };
+}
+
+pub fn deinit(self: Ast, allocator: std.mem.Allocator) void {
+    for (self.rules) |rule| {
+        rule.deinit(allocator);
+    }
+    allocator.free(self.rules);
+}
+
+test {
+    const src =
+        \\p {
+        \\    color: red;
+        \\}
+    ;
+
+    const ast = try Ast.init(std.testing.allocator, src);
+    defer ast.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualDeep(Ast{
+        .rules = &.{
+            .{
+                .style = .{
+                    .selectors = &.{
+                        .{
+                            .simple = .{
+                                .element_name = .{
+                                    .name = .{ .start = 0, .end = 1 },
+                                },
+                            },
+                        },
+                    },
+                    .declarations = &.{
+                        .{
+                            .property = .{ .start = 8, .end = 13 },
+                            .value = .{
+                                .keyword = .{ .start = 15, .end = 18 },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }, ast);
+}

--- a/src/css/Ast.zig
+++ b/src/css/Ast.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const Tokenizer = @import("Tokenizer.zig");
+const root = @import("../root.zig");
+const Span = root.Span;
 
 const Ast = @This();
 
@@ -18,18 +20,18 @@ pub const Rule = union(enum) {
                 element_name: ?ElementName,
 
                 pub const ElementName = union(enum) {
-                    name: Tokenizer.Span,
+                    name: Span,
                     all,
                 };
             };
         };
 
         pub const Declaration = struct {
-            property: Tokenizer.Span,
+            property: Span,
             value: Expression,
 
             pub const Expression = union(enum) {
-                keyword: Tokenizer.Span,
+                keyword: Span,
             };
         };
 

--- a/src/css/Ast.zig
+++ b/src/css/Ast.zig
@@ -12,17 +12,30 @@ pub const Rule = union(enum) {
     pub const Style = struct {
         selectors: []const Selector,
         declarations: []const Declaration,
+        multiline_decl: bool,
 
         pub const Selector = union(enum) {
             simple: Simple,
 
             pub const Simple = struct {
                 element_name: ?ElementName,
+                specifiers: []const Specifier,
 
                 pub const ElementName = union(enum) {
                     name: Span,
                     all,
                 };
+
+                pub const Specifier = union(enum) {
+                    hash: Span,
+                    class: Span,
+                    attrib, // TODO
+                    pseudo, // TODO
+                };
+
+                pub fn deinit(self: Simple, allocator: std.mem.Allocator) void {
+                    allocator.free(self.specifiers);
+                }
 
                 pub fn render(self: Simple, src: []const u8, out_stream: anytype) !void {
                     if (self.element_name) |element_name| {
@@ -31,8 +44,23 @@ pub const Rule = union(enum) {
                             .all => _ = try out_stream.write("*"),
                         }
                     }
+
+                    for (self.specifiers) |specifier| {
+                        switch (specifier) {
+                            .hash => |hash| try out_stream.print("#{s}", .{hash.slice(src)}),
+                            .class => |class| try out_stream.print(".{s}", .{class.slice(src)}),
+                            .attrib => @panic("TODO"),
+                            .pseudo => @panic("TODO"),
+                        }
+                    }
                 }
             };
+
+            pub fn deinit(self: Selector, allocator: std.mem.Allocator) void {
+                switch (self) {
+                    inline else => |sel| sel.deinit(allocator),
+                }
+            }
 
             pub fn render(self: Selector, src: []const u8, out_stream: anytype) !void {
                 switch (self) {
@@ -43,26 +71,76 @@ pub const Rule = union(enum) {
 
         pub const Declaration = struct {
             property: Span,
-            value: Expression,
+            value: []const Expression,
 
             pub const Expression = union(enum) {
                 keyword: Span,
+                rgb3: Rgb3,
+                rgb6: Rgb6,
+                dimension: Dimension,
+
+                pub const Rgb3 = struct {
+                    r: u4,
+                    g: u4,
+                    b: u4,
+                };
+
+                pub const Rgb6 = struct {
+                    r: u8,
+                    g: u8,
+                    b: u8,
+                };
+
+                pub const Dimension = struct {
+                    number: f32,
+                    unit: Unit,
+
+                    pub const Unit = enum {
+                        px,
+                    };
+                };
 
                 pub fn render(self: Expression, src: []const u8, out_stream: anytype) !void {
                     switch (self) {
-                        .keyword => |keyword| _ = try out_stream.write(keyword.slice(src)),
+                        .keyword => |keyword| {
+                            _ = try out_stream.write(keyword.slice(src));
+                        },
+                        .rgb3 => |rgb3| {
+                            try out_stream.print("#{x:0>1}{x:0>1}{x:0>1}", .{ rgb3.r, rgb3.g, rgb3.b });
+                        },
+                        .rgb6 => |rgb6| {
+                            try out_stream.print("#{x:0>2}{x:0>2}{x:0>2}", .{ rgb6.r, rgb6.g, rgb6.b });
+                        },
+                        .dimension => |dimension| {
+                            try out_stream.print("{d}{s}", .{ dimension.number, @tagName(dimension.unit) });
+                        },
                     }
                 }
             };
 
+            pub fn deinit(self: Declaration, allocator: std.mem.Allocator) void {
+                allocator.free(self.value);
+            }
+
             pub fn render(self: Declaration, src: []const u8, out_stream: anytype) !void {
                 _ = try out_stream.write(self.property.slice(src));
-                _ = try out_stream.write(": ");
-                try self.value.render(src, out_stream);
+                _ = try out_stream.write(":");
+                for (self.value) |expression| {
+                    _ = try out_stream.write(" ");
+                    try expression.render(src, out_stream);
+                }
             }
         };
 
         pub fn deinit(self: Style, allocator: std.mem.Allocator) void {
+            for (self.selectors) |selector| {
+                selector.deinit(allocator);
+            }
+
+            for (self.declarations) |declaration| {
+                declaration.deinit(allocator);
+            }
+
             allocator.free(self.selectors);
             allocator.free(self.declarations);
         }
@@ -77,15 +155,27 @@ pub const Rule = union(enum) {
                 try selector.render(src, out_stream);
             }
 
-            _ = try out_stream.write(" {\n");
+            _ = try out_stream.write(" {");
 
-            for (self.declarations) |declaration| {
-                for (0..depth + 1) |_| _ = try out_stream.write("    ");
-                try declaration.render(src, out_stream);
-                _ = try out_stream.write(";\n");
+            if (self.multiline_decl) {
+                _ = try out_stream.write("\n");
+
+                for (self.declarations) |declaration| {
+                    for (0..depth + 1) |_| _ = try out_stream.write("    ");
+                    try declaration.render(src, out_stream);
+                    _ = try out_stream.write(";\n");
+                }
+
+                for (0..depth) |_| _ = try out_stream.write("    ");
+            } else {
+                _ = try out_stream.write(" ");
+                for (self.declarations, 0..) |declaration, i| {
+                    if (i != 0) _ = try out_stream.write("; ");
+                    try declaration.render(src, out_stream);
+                }
+                _ = try out_stream.write(" ");
             }
 
-            for (0..depth) |_| _ = try out_stream.write("    ");
             _ = try out_stream.write("}");
         }
     };
@@ -220,8 +310,22 @@ fn parseStyleRule(s: *State) !Rule.Style {
     var declarations = std.ArrayList(Rule.Style.Declaration).init(s.allocator);
     defer declarations.deinit();
 
-    // TODO: Support multiple selectors
     try selectors.append(try parseSelector(s));
+
+    while (true) {
+        if (s.consume()) |token| {
+            if (token == .comma) {
+                if (s.peek() != null and s.peek().? == .open_curly) break;
+
+                try selectors.append(try parseSelector(s));
+            } else {
+                s.reconsume(token);
+                break;
+            }
+        } else {
+            break;
+        }
+    }
 
     if (s.consume()) |token| {
         switch (token) {
@@ -232,11 +336,26 @@ fn parseStyleRule(s: *State) !Rule.Style {
         @panic("TODO");
     }
 
-    // TODO: Support multiple declarations
     try declarations.append(try parseDeclaration(s));
 
-    if (s.peek()) |token| {
-        if (token == .semicolon) _ = s.consume();
+    var multiline_decl = false;
+
+    while (true) {
+        if (s.consume()) |token| {
+            if (token == .semicolon) {
+                if (s.peek() != null and s.peek().? == .close_curly) {
+                    multiline_decl = true;
+                    break;
+                }
+
+                try declarations.append(try parseDeclaration(s));
+            } else {
+                s.reconsume(token);
+                break;
+            }
+        } else {
+            break;
+        }
     }
 
     if (s.consume()) |token| {
@@ -251,6 +370,7 @@ fn parseStyleRule(s: *State) !Rule.Style {
     return .{
         .selectors = try selectors.toOwnedSlice(),
         .declarations = try declarations.toOwnedSlice(),
+        .multiline_decl = multiline_decl,
     };
 }
 
@@ -279,26 +399,147 @@ fn parseDeclaration(s: *State) !Rule.Style.Declaration {
 
     return .{
         .property = property,
-        .value = try parseDeclarationExpression(s),
+        .value = try parseDeclarationValue(s),
     };
 }
 
 fn parseSimpleSelector(s: *State) !Rule.Style.Selector.Simple {
-    // TODO: Support hash, class, etc.
-    // TODO: Support `*`
+    var element_name: ?Rule.Style.Selector.Simple.ElementName = null;
+
+    var specifiers = std.ArrayList(Rule.Style.Selector.Simple.Specifier).init(s.allocator);
+    defer specifiers.deinit();
+
+    if (s.consume()) |token| {
+        switch (token) {
+            .ident => |ident| element_name = .{ .name = ident },
+            .delim => |delim| switch (s.src[delim]) {
+                '*' => element_name = .all,
+                else => s.reconsume(token),
+            },
+            else => s.reconsume(token),
+        }
+    }
+
+    while (true) {
+        if (s.consume()) |token| {
+            switch (token) {
+                .hash => |hash| {
+                    var span = hash;
+                    span.start += 1;
+                    try specifiers.append(.{ .hash = span });
+                },
+                .delim => |delim| switch (s.src[delim]) {
+                    '.' => {
+                        const name_token = s.consume() orelse @panic("TODO");
+                        if (name_token != .ident) @panic("TODO");
+                        const name = name_token.ident;
+
+                        try specifiers.append(.{ .class = name });
+                    },
+                    else => @panic("TODO"),
+                },
+                .open_square => @panic("TODO"),
+                .colon => @panic("TODO"),
+                else => {
+                    s.reconsume(token);
+                    break;
+                },
+            }
+        } else {
+            break;
+        }
+    }
+
+    if (element_name == null and specifiers.items.len == 0) {
+        @panic("TODO");
+    }
 
     return .{
-        .element_name = .{
-            .name = s.consume().?.ident,
-        },
+        .element_name = element_name,
+        .specifiers = try specifiers.toOwnedSlice(),
     };
+}
+
+fn parseDeclarationValue(s: *State) ![]const Rule.Style.Declaration.Expression {
+    var value = std.ArrayList(Rule.Style.Declaration.Expression).init(s.allocator);
+    defer value.deinit();
+
+    while (s.peek()) |token| {
+        switch (token) {
+            .semicolon, .close_curly => break,
+            else => {
+                try value.append(try parseDeclarationExpression(s));
+            },
+        }
+    }
+
+    if (value.items.len == 0) {
+        @panic("TODO");
+    }
+
+    return try value.toOwnedSlice();
 }
 
 fn parseDeclarationExpression(s: *State) !Rule.Style.Declaration.Expression {
     // TODO: Support operators
-    // TODO: Support other expression types
 
-    return .{ .keyword = s.consume().?.ident };
+    if (s.consume()) |token| {
+        switch (token) {
+            .number => @panic("TODO"),
+            .percentage => @panic("TODO"),
+            .dimension => |dimension| {
+                return .{
+                    .dimension = .{
+                        .number = std.fmt.parseFloat(f32, dimension.number.slice(s.src)) catch @panic("TODO"),
+                        .unit = unit: {
+                            inline for (std.meta.fields(Rule.Style.Declaration.Expression.Dimension.Unit)) |field| {
+                                if (std.mem.eql(u8, dimension.unit.slice(s.src), field.name)) {
+                                    break :unit @enumFromInt(field.value);
+                                }
+                            }
+
+                            @panic("TODO");
+                        },
+                    },
+                };
+            },
+            .string => @panic("TODO"),
+            .ident => |ident| return .{ .keyword = ident },
+            .url => @panic("TODO"),
+            .hash => |hash| {
+                const slice = hash.slice(s.src)[1..];
+
+                for (slice) |char| {
+                    switch (char) {
+                        '0'...'9', 'a'...'f', 'A'...'F' => {},
+                        else => @panic("TODO"),
+                    }
+                }
+
+                return switch (slice.len) {
+                    6 => .{
+                        .rgb6 = .{
+                            .r = std.fmt.parseUnsigned(u8, slice[0..2], 16) catch unreachable,
+                            .g = std.fmt.parseUnsigned(u8, slice[2..4], 16) catch unreachable,
+                            .b = std.fmt.parseUnsigned(u8, slice[4..6], 16) catch unreachable,
+                        },
+                    },
+                    3 => .{
+                        .rgb3 = .{
+                            .r = std.fmt.parseUnsigned(u4, slice[0..1], 16) catch unreachable,
+                            .g = std.fmt.parseUnsigned(u4, slice[1..2], 16) catch unreachable,
+                            .b = std.fmt.parseUnsigned(u4, slice[2..3], 16) catch unreachable,
+                        },
+                    },
+                    else => @panic("TODO"),
+                };
+            },
+            .function => @panic("TODO"),
+            else => @panic("TODO"),
+        }
+    } else {
+        @panic("TODO");
+    }
 }
 
 pub fn deinit(self: Ast, allocator: std.mem.Allocator) void {
@@ -308,7 +549,7 @@ pub fn deinit(self: Ast, allocator: std.mem.Allocator) void {
     allocator.free(self.rules);
 }
 
-test {
+test "simple stylesheet" {
     const src =
         \\   p {
         \\color
@@ -326,4 +567,20 @@ test {
     defer ast.deinit(std.testing.allocator);
 
     try std.testing.expectFmt(expected, "{s}", .{ast.formatter(src)});
+}
+
+test "full example" {
+    const src =
+        \\div.foo, #bar {
+        \\    display: block;
+        \\    padding: 4px 2px;
+        \\}
+        \\
+        \\* { color: #fff }
+    ;
+
+    const ast = try Ast.init(std.testing.allocator, src);
+    defer ast.deinit(std.testing.allocator);
+
+    try std.testing.expectFmt(src, "{s}", .{ast.formatter(src)});
 }

--- a/src/css/Tokenizer.zig
+++ b/src/css/Tokenizer.zig
@@ -1,0 +1,179 @@
+const std = @import("std");
+
+const Tokenizer = @import("Tokenizer.zig");
+
+idx: u32 = 0,
+current: u8 = undefined,
+
+pub const Span = struct {
+    start: u32,
+    end: u32,
+    pub fn slice(self: Span, src: []const u8) []const u8 {
+        return src[self.start..self.end];
+    }
+};
+
+pub const Token = union(enum) {
+    ident: Span,
+    function: Span,
+    at_keyword: Span,
+    hash: Span,
+    string: Span,
+    bad_string,
+    url: Span,
+    bad_url,
+    delim: u8,
+    number: f64,
+    percentage, // TODO
+    dimension, // TODO
+    whitespace,
+    cdo,
+    cdc,
+    colon,
+    semicolon,
+    comma,
+    open_square,
+    close_square,
+    open_paren,
+    close_paren,
+    open_curly,
+    close_curly,
+};
+
+fn consume(self: *Tokenizer, src: []const u8) bool {
+    if (self.idx == src.len) {
+        return false;
+    }
+    self.current = src[self.idx];
+    self.idx += 1;
+    return true;
+}
+
+fn reconsume(self: *Tokenizer, src: []const u8) void {
+    self.idx -= 1;
+    if (self.idx == 0) {
+        self.current = undefined;
+    } else {
+        self.current = src[self.idx - 1];
+    }
+}
+
+fn peek(self: *Tokenizer, src: []const u8) ?u8 {
+    if (self.idx >= src.len) {
+        return null;
+    }
+    return src[self.idx];
+}
+
+// https://www.w3.org/TR/css-syntax-3/#ident-start-code-point
+fn isIdentStartChar(char: u8) bool {
+    return switch (char) {
+        'A'...'Z', 'a'...'z', 0x80...0xff, '_' => true,
+        else => false,
+    };
+}
+
+// https://www.w3.org/TR/css-syntax-3/#ident-code-point
+fn isIdentChar(char: u8) bool {
+    return switch (char) {
+        '0'...'9', '-' => true,
+        else => isIdentStartChar(char),
+    };
+}
+
+// https://www.w3.org/TR/css-syntax-3/#consume-token
+pub fn next(self: *Tokenizer, src: []const u8) ?Token {
+    if (self.consume(src)) {
+        switch (self.current) {
+            '\n', '\t', ' ' => while (true) {
+                if (self.peek(src)) |c| switch (c) {
+                    '\n', '\t', ' ' => std.debug.assert(self.consume(src)),
+                    else => return .whitespace,
+                } else return .whitespace;
+            },
+            '"' => @panic("TODO"),
+            '#' => @panic("TODO"),
+            '\'' => @panic("TODO"),
+            '(' => @panic("TODO"),
+            ')' => @panic("TODO"),
+            '+' => @panic("TODO"),
+            ',' => @panic("TODO"),
+            '-' => @panic("TODO"),
+            '.' => @panic("TODO"),
+            ':' => return .colon,
+            ';' => return .semicolon,
+            '<' => @panic("TODO"),
+            '@' => @panic("TODO"),
+            '[' => @panic("TODO"),
+            '\\' => @panic("TODO"),
+            ']' => @panic("TODO"),
+            '{' => return .open_curly,
+            '}' => return .close_curly,
+            '0'...'9' => @panic("TODO"),
+            else => |c| if (isIdentStartChar(c)) {
+                self.reconsume(src);
+                return self.identLike(src);
+            } else {
+                @panic("TODO");
+            },
+        }
+    } else {
+        return null;
+    }
+}
+
+// https://www.w3.org/TR/css-syntax-3/#consume-an-ident-sequence
+fn identSequence(self: *Tokenizer, src: []const u8) Span {
+    // TODO: Support escape sequences
+
+    const start = self.idx;
+
+    while (true) {
+        if (self.consume(src)) {
+            if (!isIdentChar(self.current)) {
+                self.reconsume(src);
+                break;
+            }
+        } else break;
+    }
+
+    return .{ .start = start, .end = self.idx };
+}
+
+// https://www.w3.org/TR/css-syntax-3/#consume-an-ident-like-token
+fn identLike(self: *Tokenizer, src: []const u8) Token {
+    const span = self.identSequence(src);
+
+    if (std.ascii.eqlIgnoreCase(span.slice(src), "url") and
+        self.peek(src) != null and self.peek(src).? == '(')
+    {
+        @panic("TODO");
+    } else if (self.peek(src) != null and self.peek(src).? == '(') {
+        @panic("TODO");
+    } else {
+        return .{ .ident = span };
+    }
+}
+
+test {
+    const src =
+        \\p {
+        \\    color: red;
+        \\}
+    ;
+
+    var tokenizer = Tokenizer{};
+
+    try std.testing.expectEqual(Token{ .ident = .{ .start = 0, .end = 1 } }, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token.whitespace, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token.open_curly, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token.whitespace, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token{ .ident = .{ .start = 8, .end = 13 } }, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token.colon, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token.whitespace, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token{ .ident = .{ .start = 15, .end = 18 } }, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token.semicolon, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token.whitespace, tokenizer.next(src).?);
+    try std.testing.expectEqual(Token.close_curly, tokenizer.next(src).?);
+    try std.testing.expectEqual(null, tokenizer.next(src));
+}

--- a/src/css/Tokenizer.zig
+++ b/src/css/Tokenizer.zig
@@ -1,17 +1,11 @@
 const std = @import("std");
 
 const Tokenizer = @import("Tokenizer.zig");
+const root = @import("../root.zig");
+const Span = root.Span;
 
 idx: u32 = 0,
 current: u8 = undefined,
-
-pub const Span = struct {
-    start: u32,
-    end: u32,
-    pub fn slice(self: Span, src: []const u8) []const u8 {
-        return src[self.start..self.end];
-    }
-};
 
 pub const Token = union(enum) {
     ident: Span,

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,6 +1,7 @@
 // const interpreter = @import("interpreter.zig");
 const std = @import("std");
 pub const html = @import("html.zig");
+pub const css = @import("css.zig");
 pub const Ast = @import("Ast.zig");
 // pub const SuperVM = interpreter.SuperVM;
 // pub const Exception = interpreter.Exception;


### PR DESCRIPTION
This PR introduces a CSS parser, as discussed in #4

# State
The current state of the parser is the following:
- [x] Core CSS grammar
- [x] Formatter
- [x] Simple selectors (class, id, etc.)
- [x] Pseudo-classes and pseudo-elements 
- [x] Multi-expression declarations (e.g. `padding: 4px 2px;`)
- [x] Functions (e.g. `rgb(105,12,52)`)
- [x] `@media`
- [ ] `@import`, `@font-face`, `@keyframes`, etc.
- [ ] Selector combinators (`>`, `+`, etc.)
- [ ] Attribute selectors (e.g. `a[href="..."]`)
- [ ] Full parse error coverage
- [ ] Crash stability (still has many `@panic("TODO")`)

**TLDR**: It can handle a decent amount of real-world stylesheets.

Overall, I would say it's advanced enough to have it in the main repo (although not wired in yet). Also, the fact that I'm opening a PR doesn't mean that it has to be merged right away, it means that from my side it's ready. Feel free to wait a bit before merging if you feel like doing so. I'll continue to work on my own fork until then.

### Note
I'm not sure about what branch to target. GitHub lets me change it after opening the PR, so I've left it as the default (`main`) for now.