### PR TITLE
Fix missing version field

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -19,6 +19,8 @@ pub const std_options: std.Options = .{
     .logFn = logging.logFn,
 };
 
+pub const version = build_options.version;
+
 var lsp_mode = false;
 
 pub fn panic(

--- a/src/cli/lsp.zig
+++ b/src/cli/lsp.zig
@@ -169,7 +169,8 @@ pub const Handler = struct {
         errdefer |e| log.err("changeDocument failed: {any}", .{e});
 
         if (notification.contentChanges.len == 0) {
-            return;
+            log.warn("changeDocument failed: no changes", .{});
+            return error.InternalError;
         }
 
         const file = self.files.get(notification.textDocument.uri) orelse {

--- a/src/cli/lsp.zig
+++ b/src/cli/lsp.zig
@@ -169,8 +169,7 @@ pub const Handler = struct {
         errdefer |e| log.err("changeDocument failed: {any}", .{e});
 
         if (notification.contentChanges.len == 0) {
-            log.warn("changeDocument failed: no changes", .{});
-            return error.InternalError;
+            return;
         }
 
         const file = self.files.get(notification.textDocument.uri) orelse {


### PR DESCRIPTION
After resolving llvm-conf dependency, there is still a build issue where cli.zig is missing a version field. Added it in using the build_options already available.