### PR TITLE
Make Node in named_character_references a packed struct

### DIFF
--- a/src/html/named_character_references.zig
+++ b/src/html/named_character_references.zig
@@ -62,7 +62,7 @@ fn findInList(first_child_index: u12, char: u8) ?u12 {
     unreachable;
 }
 
-pub const Node = struct {
+pub const Node = packed struct(u22) {
     char: u8,
     /// If true, this node is the end of a valid named character reference.
     /// Note: This does not necessarily mean that this node does not have child nodes.


### PR DESCRIPTION
Node being a `struct` instead of a `packed struct(u22)` was a mistake left over from me testing different struct layouts when preparing https://github.com/kristoff-it/superhtml/pull/11 (whoops!). Switching back to the intended `packed struct(u22)` gives a free speedup and a binary size decrease (minus 7KiB for me):

    Benchmark 1 (637 runs): bench-autostruct.exe
      measurement          mean ± σ            min … max           outliers         delta
      wall_time          7.85ms ±  203us    7.56ms … 11.2ms         18 ( 3%)        0%
      peak_rss           2.89MB ± 8.99KB    2.89MB … 3.12MB         39 ( 6%)        0%
    Benchmark 2 (720 runs): bench-packedstructu22.exe
      measurement          mean ± σ            min … max           outliers         delta
      wall_time          6.94ms ±  177us    6.71ms … 8.80ms         36 ( 5%)        ⚡- 11.6% ±  0.3%
      peak_rss           2.88MB ± 8.46KB    2.88MB … 3.11MB         45 ( 6%)          -  0.3% ±  0.0%