### PR TITLE
link to zed extension in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ autocmd filetype html setlocal makeprg=superhtml\ check\ %
 autocmd filetype html setlocal formatprg=superhtml\ fmt\ --stdin
 ```
 
+#### Zed
+
+See [WeetHet/superhtml-zed](https://github.com/WeetHet/superhtml-zed).
+
 #### Other editors
 Follow your editor specific instructions on how to define a new Language Server for a given language / file format.
 


### PR DESCRIPTION
Someone (@weethet) has created a Superhtml extension for Zed: https://github.com/WeetHet/superhtml-zed. I didn't find it at first, might be helpful to point it out here on the docs. I chose not to include specific installation instructions as to avoid replicating the instructions in superhtml-zed's README.