### PR TITLE
ci: bump zig to 0.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       - name: Test
         run: zig build test


### PR DESCRIPTION
CI tests fail b/c it's trying to run them with zig 0.13.0

https://github.com/kristoff-it/superhtml/actions/runs/13643243975/job/38137330368