### PR TITLE
fix serialize/deserialize tree-sitter-superhtml

### DIFF
--- a/tree-sitter-superhtml/package-lock.json
+++ b/tree-sitter-superhtml/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "tree-sitter-html",
-  "version": "0.20.3",
+  "name": "tree-sitter-superhtml",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tree-sitter-html",
-      "version": "0.20.3",
+      "name": "tree-sitter-superhtml",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/tree-sitter-superhtml/src/scanner.c
+++ b/tree-sitter-superhtml/src/scanner.c
@@ -43,15 +43,15 @@ static unsigned serialize(Scanner *scanner, char *buffer) {
             if (size + 2 + name_length >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
                 break;
             }
-            buffer[size++] = (char)tag.type;
-            buffer[size++] = (char)name_length;
+            buffer[size++] = (uint8_t)tag.type;
+            buffer[size++] = (uint8_t)name_length;
             strncpy(&buffer[size], tag.custom_tag_name.contents, name_length);
             size += name_length;
         } else {
             if (size + 1 >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
                 break;
             }
-            buffer[size++] = (char)tag.type;
+            buffer[size++] = (uint8_t)tag.type;
         }
     }
 
@@ -81,7 +81,7 @@ static void deserialize(Scanner *scanner, const char *buffer, unsigned length) {
             unsigned iter = 0;
             for (iter = 0; iter < serialized_tag_count; iter++) {
                 Tag tag = tag_new();
-                tag.type = (TagType)buffer[size++];
+                tag.type = (TagType)(uint8_t)buffer[size++];
                 if (tag.type == CUSTOM) {
                     uint16_t name_length = (uint8_t)buffer[size++];
                     array_reserve(&tag.custom_tag_name, name_length);

--- a/tree-sitter-superhtml/src/tag.h
+++ b/tree-sitter-superhtml/src/tag.h
@@ -132,6 +132,7 @@ typedef enum {
     UL,
     VAR,
     VIDEO,
+    CTX,
 
     CUSTOM,
 
@@ -150,7 +151,7 @@ typedef struct {
     String custom_tag_name;
 } Tag;
 
-static const TagMapEntry TAG_TYPES_BY_TAG_NAME[128] = {
+static const TagMapEntry TAG_TYPES_BY_TAG_NAME[129] = {
     {"AREA",       AREA      },
     {"BASE",       BASE      },
     {"BASEFONT",   BASEFONT  },
@@ -278,6 +279,7 @@ static const TagMapEntry TAG_TYPES_BY_TAG_NAME[128] = {
     {"UL",         UL        },
     {"VAR",        VAR       },
     {"VIDEO",      VIDEO     },
+    {"CTX",        CTX       },
     {"CUSTOM",     CUSTOM    },
 };
 
@@ -289,7 +291,8 @@ static const TagType TAG_TYPES_NOT_ALLOWED_IN_PARAGRAPHS[] = {
 };
 
 static TagType tag_type_for_name(const String *tag_name) {
-    for (int i = 0; i < 126; i++) {
+    int tag_names_size = sizeof TAG_TYPES_BY_TAG_NAME / sizeof TAG_TYPES_BY_TAG_NAME[0];
+    for (int i = 0; i < tag_names_size; i++) {
         const TagMapEntry *entry = &TAG_TYPES_BY_TAG_NAME[i];
         if (
             strlen(entry->tag_name) == tag_name->size &&

--- a/tree-sitter-superhtml/test/corpus/superhtml.txt
+++ b/tree-sitter-superhtml/test/corpus/superhtml.txt
@@ -1,0 +1,158 @@
+==================================
+Ctx Tag
+==================================
+
+<ctx about="$site.page('about')">
+  <a href="$ctx.about.link()" :text="$ctx.about.title"></a>
+</ctx>
+
+---
+
+(document
+  (element
+    (start_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (attribute_value))))
+    (element
+      (start_tag
+        (tag_name)
+        (attribute
+          (attribute_name)
+          (quoted_attribute_value
+            (attribute_value)))
+        (attribute
+          (attribute_name)
+          (quoted_attribute_value
+            (attribute_value))))
+      (end_tag
+        (tag_name)))
+    (end_tag
+      (tag_name))))
+
+==================================
+Super Tag
+==================================
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title id="title"><super></title>
+  </head>
+  <body id="main">
+    <super>
+  </body>
+</html>
+
+---
+
+(document
+  (doctype)
+  (element
+    (start_tag
+      (tag_name))
+    (element
+      (start_tag
+        (tag_name))
+      (element
+        (start_tag
+          (tag_name)
+          (attribute
+            (attribute_name)
+            (quoted_attribute_value
+              (attribute_value)))))
+      (element
+        (start_tag
+          (tag_name)
+          (attribute
+            (attribute_name)
+            (quoted_attribute_value
+              (attribute_value))))
+        (element
+          (start_tag
+            (tag_name)))
+        (end_tag
+          (tag_name)))
+      (end_tag
+        (tag_name)))
+    (element
+      (start_tag
+        (tag_name)
+        (attribute
+          (attribute_name)
+          (quoted_attribute_value
+            (attribute_value))))
+      (element
+        (start_tag
+          (tag_name)))
+      (end_tag
+        (tag_name)))
+    (end_tag
+      (tag_name))))
+
+==================================
+Extend Tag
+==================================
+
+<extend template="base.shtml">
+
+<title id="title" :text="$site.title"></title>
+
+<body id="main">
+  <h1 :text="$page.title"></h1>
+  <div :html="$page.content()"></div>
+</body>
+
+---
+
+(document
+  (element
+    (start_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (attribute_value)))))
+  (element
+    (start_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (attribute_value)))
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (attribute_value))))
+    (end_tag
+      (tag_name)))
+  (element
+    (start_tag
+      (tag_name)
+      (attribute
+        (attribute_name)
+        (quoted_attribute_value
+          (attribute_value))))
+    (element
+      (start_tag
+        (tag_name)
+        (attribute
+          (attribute_name)
+          (quoted_attribute_value
+            (attribute_value))))
+      (end_tag
+        (tag_name)))
+    (element
+      (start_tag
+        (tag_name)
+        (attribute
+          (attribute_name)
+          (quoted_attribute_value
+            (attribute_value))))
+      (end_tag
+        (tag_name)))
+    (end_tag
+      (tag_name))))


### PR DESCRIPTION
The origin serialize/deserialize of tree-sitter-html use type `char`. The max value is 127 while you extend the enum `TagType` for `super`, and `extend` into 128 which created UB. This problem makes the parser parse the CUSTOM tags incorrectly. I've just instead used `uint8_t` to double the size and add the testcase for superhtml specific too.

This is the problem that I see on zine-ssg.io:
![image](https://github.com/user-attachments/assets/97a03bcd-3a39-441d-98ee-8fb4a28b8915)
