### PR TITLE
fix formatting when there is content inside of multiple tight tags

### DIFF
--- a/src/html/Ast.zig
+++ b/src/html/Ast.zig
@@ -580,9 +580,15 @@ pub fn render(ast: Ast, src: []const u8, w: anytype) !void {
                     }
                 }
 
+                const child_start = ast.nodes[current.first_child_idx].open.start;
+                const child_is_vertical =
+                    current.first_child_idx != 0 and
+                    src[current.open.end..child_start].len > 0;
                 switch (current.kind) {
                     else => {},
-                    .element => indentation += 1,
+                    .element => if (child_is_vertical) {
+                        indentation += 1;
+                    },
                 }
             },
             .exit => {
@@ -599,9 +605,16 @@ pub fn render(ast: Ast, src: []const u8, w: anytype) !void {
                     current,
                 });
 
+                const child_start = ast.nodes[current.first_child_idx].open.start;
+                const child_was_vertical =
+                    current.first_child_idx != 0 and
+                    src[current.open.end..child_start].len > 0;
+
                 switch (current.kind) {
                     else => {},
-                    .element => indentation -= 1,
+                    .element => if (child_was_vertical) {
+                        indentation -= 1;
+                    },
                 }
 
                 const open_was_vertical = std.ascii.isWhitespace(src[current.open.end]);
@@ -769,7 +782,7 @@ pub fn render(ast: Ast, src: []const u8, w: anytype) !void {
                             .attr => |attr| {
                                 if (vertical) {
                                     try w.print("\n", .{});
-                                    for (0..indentation + extra) |_| {
+                                    for (0..indentation + extra + 1) |_| {
                                         try w.print("  ", .{});
                                     }
                                 } else {
@@ -795,7 +808,7 @@ pub fn render(ast: Ast, src: []const u8, w: anytype) !void {
                     }
                     if (vertical) {
                         try w.print("\n", .{});
-                        for (0..indentation + extra -| 1) |_| {
+                        for (0..indentation + extra) |_| {
                             try w.print("  ", .{});
                         }
                     }
@@ -977,6 +990,24 @@ test "newlines" {
         \\  <head></head>
         \\  <body>
         \\    <div><link></div>
+        \\  </body>
+        \\</html>
+    ;
+    const ast = try Ast.init(std.testing.allocator, case, .html);
+    defer ast.deinit(std.testing.allocator);
+
+    try std.testing.expectFmt(case, "{s}", .{ast.formatter(case)});
+}
+
+test "tight tags inner indentation" {
+    const case =
+        \\<!DOCTYPE html>
+        \\<html>
+        \\  <head></head>
+        \\  <body>
+        \\    <div><nav><ul>
+        \\      <li></li>
+        \\    </ul></nav></div>
         \\  </body>
         \\</html>
     ;

--- a/src/html/Ast.zig
+++ b/src/html/Ast.zig
@@ -580,14 +580,12 @@ pub fn render(ast: Ast, src: []const u8, w: anytype) !void {
                     }
                 }
 
-                const child_start = ast.nodes[current.first_child_idx].open.start;
-                const child_is_vertical =
-                    current.first_child_idx != 0 and
-                    src[current.open.end..child_start].len > 0;
                 switch (current.kind) {
                     else => {},
-                    .element => if (child_is_vertical) {
-                        indentation += 1;
+                    .element => if (ast.child(current)) |c| {
+                        const maybe_ws_c = src[current.open.end..c.open.start];
+                        if (c.kind == .text or maybe_ws_c.len > 0)
+                            indentation += 1;
                     },
                 }
             },
@@ -605,15 +603,12 @@ pub fn render(ast: Ast, src: []const u8, w: anytype) !void {
                     current,
                 });
 
-                const child_start = ast.nodes[current.first_child_idx].open.start;
-                const child_was_vertical =
-                    current.first_child_idx != 0 and
-                    src[current.open.end..child_start].len > 0;
-
                 switch (current.kind) {
                     else => {},
-                    .element => if (child_was_vertical) {
-                        indentation -= 1;
+                    .element => if (ast.child(current)) |c| {
+                        const maybe_ws_c = src[current.open.end..c.open.start];
+                        if (c.kind == .text or maybe_ws_c.len > 0)
+                            indentation -= 1;
                     },
                 }
 


### PR DESCRIPTION
Before, this was a possible output of `superhtml fmt`:

```
<html lang=en>
  <head></head>
  <body>
    <header><nav><ul>
          <li><a href=#>HOME</a></li>
          <li><a href=registration.html>Pricing & Registration</a></li>
          <li><a href=calendar.html>Calendar</a></li>
          <li><a href=performances.html>Performances</a></li>
          <li><a href=contact.html>Contact</a></li>
        </ul></nav></header>
    <main></main>
    <footer></footer>
  </body>
</html>
```

Now, it looks like this:

```
<html lang=en>
  <head></head>
  <body>
    <header><nav><ul>
      <li><a href=#>HOME</a></li>
      <li><a href=registration.html>Pricing & Registration</a></li>
      <li><a href=calendar.html>Calendar</a></li>
      <li><a href=performances.html>Performances</a></li>
      <li><a href=contact.html>Contact</a></li>
    </ul></nav></header>
    <main></main>
    <footer></footer>
  </body>
</html>
```

Added a test case for this, and maintained current functionality for existing test cases.