### PR TITLE
update the lsp to directly use zig-lsp-codegen instead of zig-lsp-kit

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -49,7 +49,7 @@ pub fn build(b: *std.Build) !void {
     options.addOption(Version.Kind, "version_kind", version);
 
     const folders = b.dependency("known_folders", .{});
-    const lsp = b.dependency("lsp_kit", .{});
+    const lsp = b.dependency("lsp_codegen", .{});
 
     const check = setupCheckStep(b, target, optimize, options, superhtml, folders, lsp);
     setupTestStep(b, target, superhtml, check);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,11 +2,11 @@
     .name = .superhtml,
     .version = "0.4.0",
     .fingerprint = 0xc5e9aede3c1db363,
-    .minimum_zig_version = "0.14.0-dev.3451+d8d2aa9af",
+    .minimum_zig_version = "0.14.0",
     .dependencies = .{
-        .lsp_kit = .{
-            .url = "git+https://github.com/kristoff-it/zig-lsp-kit#46e2b958c02dc4ed2d4784f8841ba7d2076da783",
-            .hash = "lsp_kit-0.1.0-hAAxO8G9AACr9SwC5FsYac37Bn7yi968x2UMq4wxKlgr",
+        .lsp_codegen = .{
+            .url = "git+https://github.com/zigtools/zig-lsp-codegen.git#eab79f82a583cf537c59009840f00d686b32d49a",
+            .hash = "lsp_codegen-0.1.0-CMjjo61BCgB43M7Rfw_zGkIn_zigAe7MMlE_Cu9p3HZ6",
         },
         .afl_kit = .{
             .url = "git+https://github.com/kristoff-it/zig-afl-kit#39c33d45dbe3605a9ef7cab863620d1ca78a3623",

--- a/src/cli/lsp.zig
+++ b/src/cli/lsp.zig
@@ -5,379 +5,242 @@ const assert = std.debug.assert;
 const lsp = @import("lsp");
 const types = lsp.types;
 const offsets = lsp.offsets;
-const ResultType = lsp.server.ResultType;
-const Message = lsp.server.Message;
 const super = @import("superhtml");
 const Document = @import("lsp/Document.zig");
+const logic = @import("lsp/logic.zig");
 
 const log = std.log.scoped(.super_lsp);
-
-const SuperLsp = lsp.server.Server(Handler);
 
 pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !void {
     _ = args;
 
     log.debug("SuperHTML LSP started!", .{});
 
-    var transport = lsp.Transport.init(
-        std.io.getStdIn().reader(),
-        std.io.getStdOut().writer(),
+    var transport: lsp.TransportOverStdio = .init(
+        std.io.getStdIn(),
+        std.io.getStdOut(),
     );
-    transport.message_tracing = false;
 
-    var server: SuperLsp = undefined;
     var handler: Handler = .{
         .gpa = gpa,
-        .server = &server,
+        .transport = transport.any(),
     };
-    server = try SuperLsp.init(gpa, &transport, &handler);
+    defer handler.deinit();
 
-    try server.loop();
+    try lsp.basic_server.run(
+        gpa,
+        transport.any(),
+        &handler,
+        log.err,
+    );
 }
 
-pub const Handler = struct {
-    gpa: std.mem.Allocator,
-    server: *SuperLsp,
-    files: std.StringHashMapUnmanaged(Document) = .{},
-    offset_encoding: offsets.Encoding = .@"utf-16",
+pub const Handler = @This();
 
-    usingnamespace @import("lsp/logic.zig");
+gpa: std.mem.Allocator,
+transport: lsp.AnyTransport,
+files: std.StringHashMapUnmanaged(Document) = .{},
+offset_encoding: offsets.Encoding = .@"utf-16",
 
-    fn windowNotification(
-        self: *Handler,
-        lvl: types.MessageType,
-        comptime fmt: []const u8,
-        args: anytype,
-    ) !void {
-        const txt = try std.fmt.allocPrint(self.gpa, fmt, args);
-        const msg = try self.server.sendToClientNotification(
-            "window/showMessage",
-            .{ .type = lvl, .message = txt },
-        );
-        defer self.gpa.free(msg);
+fn deinit(self: *Handler) void {
+    var file_it = self.files.valueIterator();
+    while (file_it.next()) |file| file.deinit(self.gpa);
+    self.files.deinit(self.gpa);
+    self.* = undefined;
+}
+
+fn windowNotification(
+    self: *Handler,
+    lvl: types.MessageType,
+    comptime fmt: []const u8,
+    args: anytype,
+) !void {
+    const txt = try std.fmt.allocPrint(self.gpa, fmt, args);
+
+    try self.transport.writeNotification(
+        self.gpa,
+        "window/showMessage",
+        types.ShowMessageParams,
+        .{ .type = lvl, .message = txt },
+        .{ .emit_null_optional_fields = false },
+    );
+}
+
+pub fn initialize(
+    self: *Handler,
+    _: std.mem.Allocator,
+    request: types.InitializeParams,
+) types.InitializeResult {
+    if (request.clientInfo) |clientInfo| {
+        log.info("client is '{s}-{s}'", .{ clientInfo.name, clientInfo.version orelse "<no version>" });
     }
 
-    pub fn initialize(
-        self: *Handler,
-        _: std.mem.Allocator,
-        request: types.InitializeParams,
-        offset_encoding_: offsets.Encoding,
-    ) !lsp.types.InitializeResult {
-        self.offset_encoding = offset_encoding_;
-
-        if (request.clientInfo) |clientInfo| {
-            log.info("client is '{s}-{s}'", .{ clientInfo.name, clientInfo.version orelse "<no version>" });
-        }
-
-        log.debug("init!", .{});
-
-        return .{
-            .serverInfo = .{
-                .name = "SuperHTML LSP",
-                .version = build_options.version,
-            },
-            .capabilities = .{
-                .positionEncoding = switch (offset_encoding_) {
-                    .@"utf-8" => .@"utf-8",
-                    .@"utf-16" => .@"utf-16",
-                    .@"utf-32" => .@"utf-32",
-                },
-                .textDocumentSync = .{
-                    .TextDocumentSyncOptions = .{
-                        .openClose = true,
-                        .change = .Full,
-                        .save = .{ .bool = true },
-                    },
-                },
-                .completionProvider = .{
-                    .triggerCharacters = &[_][]const u8{"<"},
-                },
-                .hoverProvider = .{ .bool = false },
-                .definitionProvider = .{ .bool = false },
-                .referencesProvider = .{ .bool = false },
-                .documentFormattingProvider = .{ .bool = true },
-                .semanticTokensProvider = .{
-                    .SemanticTokensOptions = .{
-                        .full = .{ .bool = false },
-                        .legend = .{
-                            .tokenTypes = std.meta.fieldNames(types.SemanticTokenTypes),
-                            .tokenModifiers = std.meta.fieldNames(types.SemanticTokenModifiers),
-                        },
-                    },
-                },
-                .inlayHintProvider = .{ .bool = false },
-            },
-        };
-    }
-
-    pub fn initialized(
-        self: *Handler,
-        _: std.mem.Allocator,
-        notification: types.InitializedParams,
-    ) !void {
-        _ = self;
-        _ = notification;
-    }
-
-    pub fn shutdown(
-        _: Handler,
-        _: std.mem.Allocator,
-        notification: void,
-    ) !?void {
-        _ = notification;
-    }
-
-    pub fn exit(
-        _: Handler,
-        _: std.mem.Allocator,
-        notification: void,
-    ) !void {
-        _ = notification;
-    }
-
-    pub fn openDocument(
-        self: *Handler,
-        arena: std.mem.Allocator,
-        notification: types.DidOpenTextDocumentParams,
-    ) !void {
-        const new_text = try self.gpa.dupeZ(u8, notification.textDocument.text); // We informed the client that we only do full document syncs
-        errdefer self.gpa.free(new_text);
-
-        const language_id = notification.textDocument.languageId;
-        const language = super.Language.fromSliceResilient(language_id) orelse {
-            log.err("unrecognized language id: '{s}'", .{language_id});
-            try self.windowNotification(
-                .Error,
-                "Unrecognized languageId, expected are: html, superhtml, xml",
-                .{},
-            );
-            @panic("unrecognized language id, exiting");
-        };
-        try self.loadFile(
-            arena,
-            new_text,
-            notification.textDocument.uri,
-            language,
-        );
-    }
-
-    pub fn changeDocument(
-        self: *Handler,
-        arena: std.mem.Allocator,
-        notification: types.DidChangeTextDocumentParams,
-    ) !void {
-        errdefer |e| log.err("changeDocument failed: {any}", .{e});
-
-        if (notification.contentChanges.len == 0) {
-            return;
-        }
-
-        const file = self.files.get(notification.textDocument.uri) orelse {
-            log.err("changeDocument failed: unknown file: {any}", .{notification.textDocument.uri});
-
-            try self.windowNotification(
-                .Error,
-                "Unrecognized languageId, expected are: html, superhtml, xml",
-                .{},
-            );
-            return error.InvalidParams;
-        };
-
-        for (notification.contentChanges) |change_| {
-            const new_text = switch (change_) {
-                .literal_1 => |change| try self.gpa.dupeZ(u8, change.text),
-                .literal_0 => |change| blk: {
-                    const old_text = file.src;
-                    const range = change.range;
-                    const start_idx = offsets.maybePositionToIndex(old_text, range.start, self.offset_encoding) orelse {
-                        log.warn("changeDocument failed: invalid start position: {any}", .{range.start});
-                        return error.InternalError;
-                    };
-                    const end_idx = offsets.maybePositionToIndex(old_text, range.end, self.offset_encoding) orelse {
-                        log.warn("changeDocument failed: invalid end position: {any}", .{range.end});
-                        return error.InternalError;
-                    };
-                    var new_text = std.ArrayList(u8).init(self.gpa);
-                    errdefer new_text.deinit();
-                    try new_text.appendSlice(old_text[0..start_idx]);
-                    try new_text.appendSlice(change.text);
-                    try new_text.appendSlice(old_text[end_idx..]);
-                    break :blk try new_text.toOwnedSliceSentinel(0);
-                },
+    if (request.capabilities.general) |general| {
+        for (general.positionEncodings orelse &.{}) |encoding| {
+            self.offset_encoding = switch (encoding) {
+                .@"utf-8" => .@"utf-8",
+                .@"utf-16" => .@"utf-16",
+                .@"utf-32" => .@"utf-32",
+                .custom_value => continue,
             };
-            errdefer self.gpa.free(new_text);
-
-            // TODO: this is a hack while we wait for actual incremental reloads
-            try self.loadFile(
-                arena,
-                new_text,
-                notification.textDocument.uri,
-                file.language,
-            );
+            break;
         }
     }
 
-    pub fn saveDocument(
-        _: Handler,
-        arena: std.mem.Allocator,
-        notification: types.DidSaveTextDocumentParams,
-    ) !void {
-        _ = arena;
-        _ = notification;
-    }
+    log.debug("init!", .{});
 
-    pub fn closeDocument(
-        self: *Handler,
-        _: std.mem.Allocator,
-        notification: types.DidCloseTextDocumentParams,
-    ) error{}!void {
-        var kv = self.files.fetchRemove(notification.textDocument.uri) orelse return;
-        self.gpa.free(kv.key);
-        kv.value.deinit(self.gpa);
-    }
-
-    pub fn completion(
-        self: Handler,
-        arena: std.mem.Allocator,
-        request: types.CompletionParams,
-    ) !ResultType("textDocument/completion") {
-        _ = self;
-        _ = arena;
-        _ = request;
-        return .{
-            .CompletionList = types.CompletionList{
-                .isIncomplete = false,
-                .items = &.{},
+    const capabilities: types.ServerCapabilities = .{
+        .positionEncoding = switch (self.offset_encoding) {
+            .@"utf-8" => .@"utf-8",
+            .@"utf-16" => .@"utf-16",
+            .@"utf-32" => .@"utf-32",
+        },
+        .textDocumentSync = .{
+            .TextDocumentSyncOptions = .{
+                .openClose = true,
+                .change = .Full,
             },
-        };
+        },
+        .documentFormattingProvider = .{ .bool = true },
+    };
+
+    if (@import("builtin").mode == .Debug) {
+        lsp.basic_server.validateServerCapabilities(Handler, capabilities);
     }
 
-    pub fn gotoDefinition(
-        self: Handler,
-        arena: std.mem.Allocator,
-        request: types.DefinitionParams,
-    ) !ResultType("textDocument/definition") {
-        _ = self;
-        _ = arena;
-        _ = request;
-        return null;
-    }
+    return .{
+        .serverInfo = .{
+            .name = "SuperHTML LSP",
+            .version = build_options.version,
+        },
+        .capabilities = capabilities,
+    };
+}
 
-    pub fn hover(
-        self: Handler,
-        arena: std.mem.Allocator,
-        request: types.HoverParams,
-        offset_encoding: offsets.Encoding,
-    ) !?types.Hover {
-        _ = self;
-        _ = arena; // autofix
-        _ = request;
-        _ = offset_encoding; // autofix
+pub fn @"textDocument/didOpen"(
+    self: *Handler,
+    arena: std.mem.Allocator,
+    notification: types.DidOpenTextDocumentParams,
+) !void {
+    const new_text = try self.gpa.dupe(u8, notification.textDocument.text);
+    errdefer self.gpa.free(new_text);
 
-        return types.Hover{
-            .contents = .{
-                .MarkupContent = .{
-                    .kind = .markdown,
-                    .value = "",
-                },
-            },
-        };
-    }
-
-    pub fn documentSymbol(
-        _: Handler,
-        _: std.mem.Allocator,
-        _: types.DocumentSymbolParams,
-    ) !ResultType("textDocument/documentSymbol") {
-        return null;
-    }
-
-    pub fn references(
-        _: Handler,
-        arena: std.mem.Allocator,
-        request: types.ReferenceParams,
-    ) !?[]types.Location {
-        _ = arena;
-        _ = request;
-        return null;
-    }
-
-    pub fn formatting(
-        self: Handler,
-        arena: std.mem.Allocator,
-        request: types.DocumentFormattingParams,
-    ) !?[]const types.TextEdit {
-        log.debug("format request!!", .{});
-
-        const doc = self.files.getPtr(request.textDocument.uri) orelse return null;
-        if (doc.html.errors.len != 0) {
-            return null;
-        }
-
-        log.debug("format!!", .{});
-
-        var buf = std.ArrayList(u8).init(arena);
-        try doc.html.render(doc.src, buf.writer());
-
-        const edits = try lsp.diff.edits(
-            arena,
-            doc.src,
-            buf.items,
-            self.offset_encoding,
+    const language_id = notification.textDocument.languageId;
+    const language = super.Language.fromSliceResilient(language_id) orelse {
+        log.err("unrecognized language id: '{s}'", .{language_id});
+        try self.windowNotification(
+            .Error,
+            "Unrecognized languageId, expected are: html, superhtml, xml",
+            .{},
         );
+        @panic("unrecognized language id, exiting");
+    };
 
-        if (builtin.mode == .Debug) {
-            if (std.mem.eql(u8, buf.items, doc.src)) {
-                std.debug.assert(edits.items.len == 0);
-            }
-        }
+    try logic.loadFile(
+        self,
+        arena,
+        new_text,
+        notification.textDocument.uri,
+        language,
+    );
+}
 
-        return edits.items;
+pub fn @"textDocument/didChange"(
+    self: *Handler,
+    arena: std.mem.Allocator,
+    notification: types.DidChangeTextDocumentParams,
+) !void {
+    if (notification.contentChanges.len == 0) {
+        return;
     }
 
-    pub fn semanticTokensFull(
-        _: Handler,
-        arena: std.mem.Allocator,
-        request: types.SemanticTokensParams,
-    ) !?types.SemanticTokens {
-        _ = arena;
-        _ = request;
-        return null;
-    }
+    const file = self.files.get(notification.textDocument.uri) orelse {
+        log.err("changeDocument failed: unknown file: {any}", .{notification.textDocument.uri});
 
-    pub fn inlayHint(
-        _: Handler,
-        arena: std.mem.Allocator,
-        request: types.InlayHintParams,
-    ) !?[]types.InlayHint {
-        _ = arena;
-        _ = request;
-        return null;
-    }
+        try self.windowNotification(
+            .Error,
+            "Unrecognized languageId, expected are: html, superhtml, xml",
+            .{},
+        );
+        return error.InvalidParams;
+    };
 
-    /// Handle a response that we have received from the client.
-    /// Doesn't usually happen unless we explicitly send a request to the client.
-    pub fn response(self: Handler, _response: Message.Response) !void {
-        _ = self;
-        const id: []const u8 = switch (_response.id) {
-            .string => |id| id,
-            .number => |id| {
-                log.warn("received response from client with id '{d}' that has no handler!", .{id});
-                return;
+    var buffer: std.ArrayListUnmanaged(u8) = .fromOwnedSlice(@constCast(file.src));
+    errdefer buffer.deinit(self.gpa);
+
+    for (notification.contentChanges) |content_change| {
+        switch (content_change) {
+            .literal_1 => |change| {
+                buffer.clearRetainingCapacity();
+                try buffer.appendSlice(self.gpa, change.text);
             },
-        };
-
-        if (_response.data == .@"error") {
-            const err = _response.data.@"error";
-            log.err("Error response for '{s}': {}, {s}", .{ id, err.code, err.message });
-            return;
+            .literal_0 => |change| {
+                const loc = offsets.rangeToLoc(buffer.items, change.range, self.offset_encoding);
+                try buffer.replaceRange(self.gpa, loc.start, loc.end - loc.start, change.text);
+            },
         }
-
-        log.warn("received response from client with id '{s}' that has no handler!", .{id});
     }
-};
 
-pub fn getRange(span: super.Span, src: []const u8) lsp.types.Range {
+    const new_text = try buffer.toOwnedSlice(self.gpa);
+    errdefer self.gpa.free(new_text);
+
+    // TODO: this is a hack while we wait for actual incremental reloads
+    try logic.loadFile(
+        self,
+        arena,
+        new_text,
+        notification.textDocument.uri,
+        file.language,
+    );
+}
+
+pub fn @"textDocument/didClose"(
+    self: *Handler,
+    _: std.mem.Allocator,
+    notification: types.DidCloseTextDocumentParams,
+) void {
+    var kv = self.files.fetchRemove(notification.textDocument.uri) orelse return;
+    self.gpa.free(kv.key);
+    kv.value.deinit(self.gpa);
+}
+
+pub fn @"textDocument/formatting"(
+    self: *const Handler,
+    arena: std.mem.Allocator,
+    request: types.DocumentFormattingParams,
+) !?[]const types.TextEdit {
+    log.debug("format request!!", .{});
+
+    const doc = self.files.getPtr(request.textDocument.uri) orelse return null;
+    if (doc.html.errors.len != 0) {
+        return null;
+    }
+
+    const range: offsets.Range = .{
+        .start = .{ .line = 0, .character = 0 },
+        .end = offsets.indexToPosition(doc.src, doc.src.len, self.offset_encoding),
+    };
+
+    log.debug("format!!", .{});
+
+    var buf = std.ArrayList(u8).init(arena);
+    try doc.html.render(doc.src, buf.writer());
+
+    return try arena.dupe(types.TextEdit, &.{.{
+        .range = range,
+        .newText = buf.items,
+    }});
+}
+
+pub fn onResponse(
+    _: *Handler,
+    _: std.mem.Allocator,
+    response: lsp.JsonRPCMessage.Response,
+) void {
+    log.warn("received unexpected response from client with id '{?}'!", .{response.id});
+}
+
+pub fn getRange(span: super.Span, src: []const u8) types.Range {
     const r = span.range(src);
     return .{
         .start = .{ .line = r.start.row, .character = r.start.col },

--- a/src/cli/lsp/logic.zig
+++ b/src/cli/lsp/logic.zig
@@ -3,7 +3,7 @@ const lsp = @import("lsp");
 const super = @import("superhtml");
 const lsp_namespace = @import("../lsp.zig");
 const Handler = lsp_namespace.Handler;
-const getRange = lsp_namespace.getRange;
+const getRange = Handler.getRange;
 const Document = @import("Document.zig");
 
 const log = std.log.scoped(.ziggy_lsp);
@@ -11,7 +11,7 @@ const log = std.log.scoped(.ziggy_lsp);
 pub fn loadFile(
     self: *Handler,
     arena: std.mem.Allocator,
-    new_text: [:0]const u8,
+    new_text: []const u8,
     uri: []const u8,
     language: super.Language,
 ) !void {
@@ -73,10 +73,11 @@ pub fn loadFile(
         }
     }
 
-    const msg = try self.server.sendToClientNotification(
+    try self.transport.writeNotification(
+        self.gpa,
         "textDocument/publishDiagnostics",
+        lsp.types.PublishDiagnosticsParams,
         res,
+        .{ .emit_null_optional_fields = false },
     );
-
-    defer self.gpa.free(msg);
 }


### PR DESCRIPTION
Over time I have worked on moving more of ZLS's lsp related utilities into [zig-lsp-codegen](https://github.com/zigtools/zig-lsp-codegen) and made it usable as a library which wasn't the case when [zig-lsp-kit](https://github.com/kristoff-it/zig-lsp-kit). was created. This means that there can be one less dependency to maintain for superhtml and ziggy while still having access to most of the utilities that were provided by zig-lsp-kit.

I have made the same changes for ziggy as well. If this change is welcome, I can send a PR for ziggy as well.