### PR TITLE
Add trailing newlines to help messages of check, interface, and fmt

### DIFF
--- a/src/cli/check.zig
+++ b/src/cli/check.zig
@@ -289,6 +289,7 @@ const Command = struct {
             \\                    and SuperHTML files. 
             \\
             \\   --help, -h       Prints this help and exits.
+            \\
         , .{});
 
         std.process.exit(1);

--- a/src/cli/fmt.zig
+++ b/src/cli/fmt.zig
@@ -321,6 +321,7 @@ const Command = struct {
             \\                      and SuperHTML files. 
             \\
             \\   --help, -h         Prints this help and exits.
+            \\
         , .{});
 
         std.process.exit(1);

--- a/src/cli/interface.zig
+++ b/src/cli/interface.zig
@@ -175,6 +175,7 @@ const Command = struct {
             \\                    and SuperHTML files. 
             \\
             \\   --help, -h       Prints this help and exits.
+            \\
         , .{});
 
         std.process.exit(1);


### PR DESCRIPTION
`superhtml --help` already outputs a trailing newline, but `superhtml check --help`, `superhtml interface --help`, and `superhtml fmt --help` currently do not. This change fixes the help messages of those commands. (The remaining commands, `lsp`, `help`, and `version` do not have dedicated help messages.)

Rationale (which I assume everyone reading this already knows, but I'll mention just in case): When the output of a CLI fails to end with a newline, the next shell prompt (in most default shell setups) gets drawn at the end of the last line of output. This is a mild annoyance to someone like me who is exploring the CLI for the first time and checking the help repeatedly.