### PR TITLE
Fix handling of --no-strict-tags in fmt command

### DIFF
--- a/src/cli/fmt.zig
+++ b/src/cli/fmt.zig
@@ -237,7 +237,7 @@ const Command = struct {
             }
 
             if (std.mem.eql(u8, arg, "--no-strict-tags")) {
-                strict = true;
+                strict = false;
                 continue;
             }
 


### PR DESCRIPTION
Currently, `--no-strict-tags` has no effect in the `fmt` command because the code mistakenly sets `strict` to true instead of false when the flag is present:

https://github.com/kristoff-it/superhtml/blob/8cb16babb0c66b6512d6aeb4cbc37ed90641d980/src/cli/fmt.zig#L239-L240

Current behavior:
```
$ superhtml fmt test.html; echo $?
test.html:0:1: invalid_html_tag_name
1
$ superhtml fmt --no-strict-tags test.html; echo $?
test.html:0:1: invalid_html_tag_name
1
```
With this change:
```
$ superhtml fmt test.html; echo $?
test.html:0:1: invalid_html_tag_name
1
$ superhtml fmt --no-strict-tags test.html; echo $?
0
```