### PR TITLE
Add option to allow self-closing void tags

### DIFF
--- a/src/cli/interface.zig
+++ b/src/cli/interface.zig
@@ -6,8 +6,8 @@ const FileType = enum { html, super };
 pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !void {
     const cmd = Command.parse(args);
     const options = super.html.Ast.ParseOptions{
-        .strict_tags = cmd.strict,
-        .self_closing_void = .never,
+        .strict_tags = cmd.strict_tags,
+        .self_closing_void = if (cmd.self_closing_void) .preserve else .never,
     };
     switch (cmd.mode) {
         .stdin => {
@@ -101,7 +101,8 @@ fn oom() noreturn {
 
 const Command = struct {
     mode: Mode,
-    strict: bool,
+    strict_tags: bool,
+    self_closing_void: bool,
 
     const Mode = union(enum) {
         stdin,
@@ -110,7 +111,8 @@ const Command = struct {
 
     fn parse(args: []const []const u8) Command {
         var mode: ?Mode = null;
-        var strict: ?bool = null;
+        var strict_tags: ?bool = null;
+        var self_closing_void: ?bool = null;
 
         var idx: usize = 0;
         while (idx < args.len) : (idx += 1) {
@@ -122,7 +124,12 @@ const Command = struct {
             }
 
             if (std.mem.eql(u8, arg, "--no-strict-tags")) {
-                strict = false;
+                strict_tags = false;
+                continue;
+            }
+
+            if (std.mem.eql(u8, arg, "--self-closing-void")) {
+                self_closing_void = true;
                 continue;
             }
 
@@ -160,7 +167,8 @@ const Command = struct {
 
         return .{
             .mode = m,
-            .strict = strict orelse true,
+            .strict_tags = strict_tags orelse true,
+            .self_closing_void = self_closing_void orelse false,
         };
     }
 

--- a/src/cli/lsp.zig
+++ b/src/cli/lsp.zig
@@ -26,7 +26,7 @@ pub fn run(gpa: std.mem.Allocator, args: []const []const u8) !void {
     var handler: Handler = .{
         .gpa = gpa,
         .transport = &stdio.transport,
-        .strict = true,
+        .strict_tags = true,
     };
     defer handler.deinit();
 
@@ -44,7 +44,7 @@ gpa: std.mem.Allocator,
 transport: *lsp.Transport,
 files: std.StringHashMapUnmanaged(Document) = .{},
 offset_encoding: offsets.Encoding = .@"utf-16",
-strict: bool,
+strict_tags: bool,
 
 fn deinit(self: *Handler) void {
     var file_it = self.files.valueIterator();
@@ -274,7 +274,7 @@ pub fn @"textDocument/codeAction"(
         self.offset_encoding,
     );
 
-    if (!self.strict) return null;
+    if (!self.strict_tags) return null;
 
     for (doc.html.errors) |err| {
         if (err.tag != .invalid_html_tag_name) continue;

--- a/src/cli/lsp/Document.zig
+++ b/src/cli/lsp/Document.zig
@@ -20,12 +20,12 @@ pub fn init(
     gpa: std.mem.Allocator,
     src: []const u8,
     language: super.Language,
-    strict: bool,
+    options: super.html.Ast.ParseOptions,
 ) error{OutOfMemory}!Document {
     var doc: Document = .{
         .src = src,
         .language = language,
-        .html = try super.html.Ast.init(gpa, src, language, strict),
+        .html = try super.html.Ast.init(gpa, src, language, options),
     };
     errdefer doc.html.deinit(gpa);
 
@@ -38,9 +38,13 @@ pub fn init(
     return doc;
 }
 
-pub fn reparse(doc: *Document, gpa: std.mem.Allocator, strict: bool) !void {
+pub fn reparse(
+    doc: *Document,
+    gpa: std.mem.Allocator,
+    options: super.html.Ast.ParseOptions,
+) !void {
     doc.deinit(gpa);
-    doc.html = try super.html.Ast.init(gpa, doc.src, doc.language, strict);
+    doc.html = try super.html.Ast.init(gpa, doc.src, doc.language, options);
     errdefer doc.html.deinit(gpa);
 
     if (doc.language == .superhtml and doc.html.errors.len == 0) {

--- a/src/cli/lsp/logic.zig
+++ b/src/cli/lsp/logic.zig
@@ -22,11 +22,16 @@ pub fn loadFile(
         .diagnostics = &.{},
     };
 
+    const options = super.html.Ast.ParseOptions{
+        .strict_tags = self.strict_tags,
+        .self_closing_void = .never,
+    };
+
     const doc = try Document.init(
         self.gpa,
         new_text,
         language,
-        self.strict,
+        options,
     );
 
     log.debug("document init", .{});

--- a/src/html/Ast.zig
+++ b/src/html/Ast.zig
@@ -390,12 +390,14 @@ pub const Error = struct {
     node_idx: u32, // 0 = missing node
 };
 
+pub const SelfClosingVoidMode = enum { never, preserve, always };
+
 pub const ParseOptions = struct {
     /// When true only official HTML tag names will be allowed.
     /// Strict mode currently only supports HTML and SuperHTML.
     strict_tags: bool,
     /// How to handle self-closing HTML void tags like <br />.
-    self_closing_void: enum { never, preserve, always },
+    self_closing_void: SelfClosingVoidMode,
 };
 
 pub fn cursor(ast: Ast, idx: u32) Cursor {


### PR DESCRIPTION
à la Pretter.

For `lsp` and `fmt`, there are three modes:
- `never`: Treat `<br />` as invalid, and convert to a void tag when doing an LSP format. (Default. Should match status quo.)
- `preserve`: Accept `<br />`, but do not automatically add or remove the slashes.
- `always`: Automatically convert all void elements into self-closing tags.

To do:
- Help text (I wasn't sure how to format it.)
- Expose the option through something other than command-line args. My changes are fine for me in Helix, but there's no way to specify it in VS Code.
- Five modes instead of three? (forbid, remove, preserve, insert, require)

(This is my first time writing any Zig. I've probably done something quite dubious.)