### PR TITLE
Fix CI to use OS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,4 +18,3 @@ jobs:
 
       - name: Test
         run: zig build test
-          


### PR DESCRIPTION
The workflow already defined an OS matrix, but `runs-on` was hardcoded to `ubuntu-latest`. This is visible in the Windows job logs, where the "Set up job" step reports the operating system as Ubuntu: https://github.com/kristoff-it/superhtml/actions/runs/18610783433/job/53068568320.

This makes the job correctly use `matrix.os` so tests run on different platforms instead of three times on the same one.