### PR TITLE
Implement embedded content category per WHATWG spec

### DIFF
--- a/src/html/Element.zig
+++ b/src/html/Element.zig
@@ -165,7 +165,7 @@ pub const Categories = packed struct {
     sectioning: bool = false,
     heading: bool = false,
     interactive: bool = false,
-    // embedded: bool = false,
+    embedded: bool = false,
 
     pub const none: Categories = .{};
     pub const all: Categories = .{
@@ -176,7 +176,7 @@ pub const Categories = packed struct {
         .sectioning = true,
         .heading = true,
         .interactive = true,
-        // .embedded = true,
+        .embedded = true,
     };
     // Just for clarity
     pub const transparent: Categories = .all;

--- a/src/html/elements/audio_video.zig
+++ b/src/html/elements/audio_video.zig
@@ -34,7 +34,7 @@ pub const audio: Element = .{
         .categories = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
         },
         .content = .transparent,
     },
@@ -42,7 +42,7 @@ pub const audio: Element = .{
         .categories_superset = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
             .interactive = true,
         },
     },

--- a/src/html/elements/canvas.zig
+++ b/src/html/elements/canvas.zig
@@ -17,7 +17,7 @@ pub const canvas: Element = .{
         .categories = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
         },
         .content = .transparent,
     },
@@ -25,7 +25,7 @@ pub const canvas: Element = .{
         .categories_superset = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
         },
         .content_reject = .{
             .interactive = true,

--- a/src/html/elements/embed.zig
+++ b/src/html/elements/embed.zig
@@ -15,7 +15,7 @@ pub const embed: Element = .{
         .categories = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
             .interactive = true,
         },
         .content = .none,
@@ -24,7 +24,7 @@ pub const embed: Element = .{
         .categories_superset = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
             .interactive = true,
         },
     },

--- a/src/html/elements/iframe.zig
+++ b/src/html/elements/iframe.zig
@@ -16,7 +16,7 @@ pub const iframe: Element = .{
         .categories = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
             .interactive = true,
         },
         .content = .none,
@@ -25,7 +25,7 @@ pub const iframe: Element = .{
         .categories_superset = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
             .interactive = true,
         },
     },

--- a/src/html/elements/img.zig
+++ b/src/html/elements/img.zig
@@ -15,7 +15,7 @@ pub const img: Element = .{
         .categories = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
         },
         .content = .none, // void
     },
@@ -23,7 +23,7 @@ pub const img: Element = .{
         .categories_superset = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
             .interactive = true,
         },
     },

--- a/src/html/elements/math.zig
+++ b/src/html/elements/math.zig
@@ -14,11 +14,11 @@ const AttributeSet = Attribute.AttributeSet;
 pub const math: Element = .{
     .tag = .math,
     .model = .{
-        .categories = .{ .flow = true },
+        .categories = .{ .flow = true, .phrasing = true, .embedded = true },
         .content = .none,
     },
     .meta = .{
-        .categories_superset = .{ .flow = true },
+        .categories_superset = .{ .flow = true, .phrasing = true, .embedded = true },
     },
     .attributes = .static,
     .content = .model,

--- a/src/html/elements/object.zig
+++ b/src/html/elements/object.zig
@@ -17,7 +17,7 @@ pub const object: Element = .{
         .categories = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
         },
         .content = .transparent,
     },
@@ -25,7 +25,7 @@ pub const object: Element = .{
         .categories_superset = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
         },
     },
     .attributes = .{

--- a/src/html/elements/picture.zig
+++ b/src/html/elements/picture.zig
@@ -16,7 +16,7 @@ pub const picture: Element = .{
         .categories = .{
             .flow = true,
             .phrasing = true,
-            // .embedded = true,
+            .embedded = true,
             // .palpable = true,
         },
         .content = .none,

--- a/src/html/elements/svg.zig
+++ b/src/html/elements/svg.zig
@@ -4,11 +4,11 @@ const Element = @import("../Element.zig");
 pub const svg: Element = .{
     .tag = .svg,
     .model = .{
-        .categories = .{ .flow = true },
+        .categories = .{ .flow = true, .phrasing = true, .embedded = true },
         .content = .none,
     },
     .meta = .{
-        .categories_superset = .{ .flow = true },
+        .categories_superset = .{ .flow = true, .phrasing = true, .embedded = true },
     },
     .attributes = .manual, // we just don't do it
     .content = .model,


### PR DESCRIPTION
Add the seventh content category (embedded) to the Categories struct and enable it on all embedded content elements: img, video, audio, iframe, embed, object, picture, svg, math, canvas.

Also adds phrasing category to svg and math elements, as the spec requires embedded content to be a subset of phrasing content.

Spec: https://html.spec.whatwg.org/multipage/dom.html#embedded-content-2