### PR TITLE
Allow del and ins as phrasing content with transparent content model

### DIFF
--- a/src/html/elements/ins_del.zig
+++ b/src/html/elements/ins_del.zig
@@ -31,10 +31,18 @@ pub const ins: Element = .{
 pub const del: Element = .{
     .tag = .del,
     .model = .{
-        .categories = .none,
-        .content = .{ .flow = true },
+        .categories = .{
+            .flow = true,
+            .phrasing = true,
+        },
+        .content = .transparent,
     },
-    .meta = .{ .categories_superset = .none },
+    .meta = .{
+        .categories_superset = .{
+            .flow = true,
+            .phrasing = true,
+        },
+    },
     .attributes = .static,
     .content = .model,
     .desc =


### PR DESCRIPTION
Allow `del` and `ins` as phrasing content with transparent content model. 

Fixes https://github.com/kristoff-it/superhtml/issues/127