### PR TITLE
Fix remaining emtpy typos in validation messages

### DIFF
--- a/src/html/Attribute.zig
+++ b/src/html/Attribute.zig
@@ -90,7 +90,7 @@ pub const Rule = union(enum) {
     /// An entry in a static list of options
     list: List,
 
-    /// A valid url. Value decides if emtpy string is allowed or not.
+    /// A valid url. Value decides if empty string is allowed or not.
     url: enum { empty, not_empty },
 
     /// Custom validation
@@ -604,7 +604,7 @@ pub fn validateMime(
         if (mime_type.len == 0) return errors.append(gpa, .{
             .tag = .{
                 .invalid_attr_value = .{
-                    .reason = "emtpy MIME type",
+                    .reason = "empty MIME type",
                 },
             },
             .main_location = .{
@@ -658,7 +658,7 @@ pub fn validateMime(
     if (subtype.len == 0) return errors.append(gpa, .{
         .tag = .{
             .invalid_attr_value = .{
-                .reason = "emtpy MIME subtype",
+                .reason = "empty MIME subtype",
             },
         },
         .main_location = .{
@@ -702,7 +702,7 @@ pub fn validateMime(
         if (param_name.len == 0) return errors.append(gpa, .{
             .tag = .{
                 .invalid_attr_value = .{
-                    .reason = "emtpy MIME parameter name",
+                    .reason = "empty MIME parameter name",
                 },
             },
             .main_location = .{


### PR DESCRIPTION
Refs #121.

This fixes the remaining `emtpy` misspellings on current `main` in `src/html/Attribute.zig`: one comment and three validation messages. The two `input.zig` validation messages from the issue are already spelled correctly on current `main`, so I left them unchanged.

Validation:
- `rg -n "emtpy" .` returns no matches after the change
- `/tmp/codex-zig-superhtml-exact/zig fmt --check src/html/Attribute.zig`
- `/tmp/codex-zig-superhtml-exact/zig build test`
- `git diff --check`

I used the Zig `0.17.0-dev.702+18b3c78a9` build declared by `build.zig.zon` for the build check.