### PR TITLE
do not require sizes attribute on <source> without width descriptor

### DIFF
--- a/src/html/elements/picture.zig
+++ b/src/html/elements/picture.zig
@@ -204,8 +204,12 @@ fn validate(
                         continue;
                     }
 
-                    if (!img_allow_autosizes) try errors.append(gpa, .{
-                        .tag = .{ .missing_required_attr = "sizes" },
+                    if (seen_any_w and !img_allow_autosizes) try errors.append(gpa, .{
+                        .tag = .{
+                            .missing_required_attr =
+                            \\presence of a width descriptor requires 'sizes' attribute to be present 
+                            ,
+                        },
                         .main_location = vait.name,
                         .node_idx = child_idx,
                     });


### PR DESCRIPTION
A `<source>` element whose parent is a `<picture>` element has the following requirements:

1. If the srcset attribute has any image candidate strings using a width descriptor, the sizes attribute may also be present.
2. If, additionally, the following sibling img element does not allow auto-sizes, the sizes attribute must be present.

[Spec](https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element:~:text=If%20the%20srcset,element%20is%20selected.)

If my reading of the spec is correct, the second requirement only applies if the first requirement applies, that is, if a width descriptor is present. Therefore, if no width descriptor is present, a sizes attribute must not be present.

The validation logic however rejects this case and will force you to add both a width descriptor and a 'sizes' attribute:

```html
<picture>
    <source srcset="image-dark.png" media="(prefers-color-scheme: dark)">
    <img src="image.png" alt="">
</picture>
```

```
example.html:1:2: missing required attribute(s): sizes
   <source srcset="image-dark.png" media="(prefers-color-scheme: dark)">
    ^^^^^^
```

After adding a 'sizes' attribute as suggested, it will continue to complain:

```
example.html:1:9: invalid attribute combination: presence of 'sizes' requires image string candidates to specify width descriptors
   <source srcset="image-dark.png" media="(prefers-color-scheme: dark)" sizes="100px">
           ^^^^^^
```
