### PR TITLE
Fix Warning and Tip admonitions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ General Options:
   --syntax-only     Disable HTML element and attribute validation.
 ```
 
-> [!WARNING] SuperHTML only supports HTML5 (the WHATWG living spec)
+> [!WARNING]
+> SuperHTML only supports HTML5 (the WHATWG living spec)
 > regardless of what you put in your doctype (a warning will be generated
 > for unsupported doctypes).
 
-> [!WARNING] Templated HTML (Jinja2, Angular, Mustache, ...) is not yet
+> [!WARNING]
+> Templated HTML (Jinja2, Angular, Mustache, ...) is not yet
 > supported when all validation rules are enabled, use `--syntax-only` (or
 > the relative Extension Setting in VSCode) to limit validation to syntax
 > errors to use SuperHTML with templated HTML documents.
@@ -55,7 +57,8 @@ request for horizontal / vertical alignment.
 2. Adding / removing whitespace between the **last attribute** of a start
    tag and the closing `>`.
 
-> [!TIP] Consider using `superhtml fmt --check` in your CI to enforce every
+> [!TIP]
+> Consider using `superhtml fmt --check` in your CI to enforce every
 > change to be performed on normalized HTML files. This is a technique
 > commonly used in Zig (and Go) for source code that can also help
 > streamline frontend development.


### PR DESCRIPTION
Github was not rendering the full admonition for a couple Warnings and a Tip. Evidently the first line must be reserved for the specified admonition. See [the docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).