### PR TITLE
fix: enforce `<progress>` attr `[max]>0` and `[value]>=0`

### DIFF
--- a/src/html/elements/progress.zig
+++ b/src/html/elements/progress.zig
@@ -114,7 +114,7 @@ fn validate(
             return progress.model;
         };
 
-        if (number < 0) {
+        if (number <= 0) {
             try errors.append(gpa, .{
                 .tag = .{
                     .invalid_attr_value = .{
@@ -155,11 +155,11 @@ fn validate(
             return progress.model;
         };
 
-        if (number <= 0) {
+        if (number < 0) {
             try errors.append(gpa, .{
                 .tag = .{
                     .invalid_attr_value = .{
-                        .reason = "must be greater than zero",
+                        .reason = "must be greater than or equal to zero",
                     },
                 },
                 .main_location = attr.name,
@@ -169,7 +169,7 @@ fn validate(
             try errors.append(gpa, .{
                 .tag = .{
                     .invalid_attr_value = .{
-                        .reason = "must be lower or equal than [max] (defaults to 1.0)",
+                        .reason = "must be lower than or equal to [max] (defaults to 1.0)",
                     },
                 },
                 .main_location = attr.name,


### PR DESCRIPTION

- undo https://github.com/kristoff-it/superhtml/commit/151355314afe34b9889813a2c8e6a6281168eb07 as it accidentally changed `max`-attr validation
  Spec: [`The max attribute, if present, must have a value greater than zero.`](https://html.spec.whatwg.org/#attr-progress-max:~:text=The%20max%20attribute%2C%20if%20present%2C%20must%20have%20a%20value%20greater%20than%20zero)
- fix #95 (for real), `value=0` isn't shown as invalid anymore
  Spec: [`The value attribute, if present, must have a value greater than or equal to zero, [...]`](https://html.spec.whatwg.org/#attr-progress-value:~:text=The%20value%20attribute%2C%20if%20present%2C%20must%20have%20a%20value%20greater%20than%20or%20equal%20to%20zero)

Also fixes related error reason wording.