### PR TITLE
Undo fixing of unclosed li in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ common example is `<li>`, which enables this usage pattern:
 
 ```html
 <ul>
-  <li>First point</li>
-  <li>Second point</li>
+  <li>First point
+  <li>Second point
 </ul>
 ```
 
@@ -279,8 +279,7 @@ documents, it creates a problematic gray area when it comes to typos.
 Consider the following snippet:
 
 ```html
-<li>first point</li>
-<li></li>
+<li>first point<li>
 ```
 
 If SuperHTML were to follow the HTML spec it would have to consider this


### PR DESCRIPTION
These examples were "fixed" to be "superhtml correct" in 4d7bb5e but it didn't make sense to do so. These examples are explaining why superhtml does not allow unclosed `<li>` and say "consider the following examples" which are not unclosed `<li>` at all, very confusing.

So bring back the unclosed `<li>` so they are good examples.